### PR TITLE
Use kube-rs's proxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-socks5"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da2537846e16b96d2972ee52a3b355663872a1a687ce6d57a3b6f6b6a181c89"
+dependencies = [
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +466,7 @@ checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -479,10 +490,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -505,6 +538,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -702,6 +736,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-socks2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dece4a1fc902064ecde5c2c2b3aa01e8848164013b6e5e82cba89c4c7483e97c"
+dependencies = [
+ "async-socks5",
+ "futures",
+ "http",
+ "hyper",
+ "hyper-util",
+ "thiserror",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +887,7 @@ dependencies = [
  "hyper",
  "hyper-http-proxy",
  "hyper-rustls",
+ "hyper-socks2",
  "hyper-timeout",
  "hyper-util",
  "jsonpath-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ hyper = { version = "1.3.1" }
 hyper-rustls = { version = "0.27.1" }
 hyper-util = { version = "0.1.3", features = ["client-legacy"] }
 k8s-openapi = { version = "0.22.0", default-features = false, features=["v1_24"] }
-kube = { version = "0.92.0", default-features = false, features = ["client", "rustls-tls"]}
+kube = { version = "0.92.0", default-features = false, features = ["client", "rustls-tls", "socks5", "http-proxy"]}
 kube-derive = { version = "0.92.0"}
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-rustls = "0.26.0"


### PR DESCRIPTION
We switch the kube-rs client creation to use `Client::try_from(Config)` which builds a client from the provided kubectl config.

Additionally, we enable the `socks5` and `http-proxy` features in kube-rs which gives us support for kubectl configs that use `server.proxy-url`.

Fixes #33