### PR TITLE
Make `tracing_subscriber` configurable via `KUBECTL_WHY_CAN_LOG`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,8 +1300,17 @@ checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1303,8 +1321,14 @@ checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.4",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1803,10 +1827,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ tokio = { version = "1.37.0", features = ["full"] }
 tokio-rustls = "0.26.0"
 tower = { version = "0.4.13", features = ["limit"] }
 tower-http = { version = "0.5.2", features = ["trace", "decompression-gzip"] }
-tracing-subscriber = "0.3.18"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # kubectl-why-can
 Kubectl plugin to determine **why** a principal can perform an action. This is a simple wrapper around the Kubernetes `SelfSubjectAccessReview` API. The CLI format is modelled after the built-in `kubectl auth can-i`.
+
+## Configuring log verbosity
+
+Set environment variable `KUBECTL_WHY_CAN_LOG` to control the log verbosity.
+By default, only errors are logged.
+
+You can customize log verbosity for different subsystems.
+For example, to enable debug logging only for the Kubernetes client library, you can use `KUBECTL_WHY_CAN_LOG="info,kube=debug"`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ use k8s_openapi::api::authorization::v1::{
 
 use kube::{api::ObjectMeta, Api, Client, Config};
 
+use tracing_subscriber::{prelude::*, EnvFilter};
+
 fn create_self_subject_access_review(
     group: Option<String>,
     name: Option<String>,
@@ -91,8 +93,10 @@ impl Cli {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    std::env::set_var("RUST_LOG", "info,kube=trace");
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(EnvFilter::from_env("KUBECTL_WHY_CAN_LOG"))
+        .init();
 
     // set process-wide default crypto provider to the rustls aws-lc implementation.
     let _ = tokio_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();


### PR DESCRIPTION
The variable behaves similarly to `RUST_LOG`. See the README for a small example.