### PR TITLE
Refactor release summary rendering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,15 +119,17 @@ jobs:
           git fetch origin +refs/tags/*:refs/tags/*
           # Extract tag message
           TAG_MSG=$(git tag -n --format='%(contents:body)' ${GITHUB_REF##refs/tags/} | tr -d '\r')
-          # Escape literal % and newlines (\n, \r) for github actions output
-          TAG_MSG=${TAG_MSG//'%'/%25}
-          TAG_MSG=${TAG_MSG//$'\n'/%0A}
           # Join multiple lines belonging to the same paragraph for GitHub
           # markdown.
-          # Paragraph breaks should be %0A%0A. We replace single line breaks
-          # with a space with sed.
-          TAG_MSG=$(echo ${TAG_MSG} |sed 's/\([^A]\)%0A\([^%]\)/\1 \2/g')
-          # Set action output `messsage`
+          # Paragraph breaks should be '\n\n'. List items should be '\n*'. We
+          # replace single line breaks which don't preceed a '*' with a space
+          # with sed. Note `sed -z` operates on the whole input instead of
+          # line-wise. Note that this currently still breaks markdown code
+          # blocks.
+          TAG_MSG=$(echo "$TAG_MSG" | sed -z 's/\([^\n]\)\n\([^\n\*]\)/\1 \2/g')
+          # Set action output `messsage` as JSON-encoded string to preserve
+          # newlines. We decode with `fromJSON()` below.
+          TAG_MSG=$(jq -n --arg msg "${TAG_MSG}" '$msg')
           echo "message=${TAG_MSG}" >> $GITHUB_OUTPUT
         env:
           GITHUB_REF: ${{ github.ref }}
@@ -152,7 +154,7 @@ jobs:
           body: |
             ## Summary
 
-            ${{steps.tag_message.outputs.message}}
+            ${{fromJSON(steps.tag_message.outputs.message)}}
 
             ## Changes
 


### PR DESCRIPTION
The new output parameter interface which uses `$GITHUB_OUTPUT` doesn't need escaping of newlines anymore. We adjust the script that extracts the summary from the annotated tag to only remove single linebreaks instead of escaping newlines.

## TODO

- [x] Test in https://github.com/simu/actions-testing/blob/master/.github/workflows/release.yaml